### PR TITLE
コマンドラインの./gradlewでビルドできないので、repositoriesを追加。

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         maven { url 'https://maven.fabric.io/public' }
+        jcenter()
         google()
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
@@ -14,6 +15,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
         flatDir {
             dirs 'libs'
         }


### PR DESCRIPTION
Android Studioでビルドすると、勝手にrepositoriesにgoogle()等が追加されますが、コマンドラインでビルドするとそれが起こらないので、ビルドに失敗します。
適当にrepositoriesに追加したので、不要なものも混じっているかもしれません。