### PR TITLE
指でflingしたときに、途中でスクロールが止まる。また、ビデオを２回タップしないと再生されない。

### DIFF
--- a/app/src/main/res/layout/video_item.xml
+++ b/app/src/main/res/layout/video_item.xml
@@ -6,7 +6,7 @@
     android:background="@drawable/item_background"
     android:clickable="true"
     android:focusable="true"
-    android:focusableInTouchMode="true"
+    android:focusableInTouchMode="false"
     android:paddingBottom="1dp">
 
     <LinearLayout


### PR DESCRIPTION
Pixel(Android P)で以下の症状が起きていたのですが、このpatchで直りました。
・flingしたときに、スクロールが直ぐに止まる
・ビデオを(list itemを)２回タップしないと、再生が始まらない

参考:
https://stackoverflow.com/questions/31023526/recyclerview-clicking-twice

他にもandroid:focusableInTouchMode="true"の箇所が何ヶ所かあるので、そちらも変更していただけるとありがたいです。
